### PR TITLE
Clarified the previous experience clause.

### DIFF
--- a/guidelines/reviewer-guidelines.rst
+++ b/guidelines/reviewer-guidelines.rst
@@ -7,9 +7,9 @@ Role of Reviewers
    will be interacting with proposers through junction setup for CFP
    (http://in.pycon.org/cfp/pycon-india-2015/proposals/)
 -  Reviewers will be judging the proposal purely based on content.
--  Reviewers shouldn't discriminate proposers based on previous
-   experience as first timers are allowed if the speaker has adequate
-   hands on experience on the topic.
+-  Reviewers should not give too much weightage to the past speaking experience
+   of the speaker as PyCon India would like to encourage first time speakers.
+   However, make sure the speaker is well qualified to give a talk on that topic.
 -  Reviewers are recommended to provide feedback from the early stage of
    submission to help improve the quality of talks and ease the
    selection of final list of talks.


### PR DESCRIPTION
The previous experience clause was ambiguous. 

    Reviewers shouldn't discriminate proposers based on previous
    experience as first timers are allowed if the speaker has adequate
    hands on experience on the topic.

On one hand, it says previous experience should not be considered and on the other hand, it asks the reviewers to make sure that the speaker has experience on the topic.

I think we are getting confused about "past speaking experience" and "expertise on the topic". PyCon India would like to encourage first time speakers. So it is fine to not have past speaking experience, but they must be qualified on that topic to give a talk.

I've modified that statement to the following to make it better.

    Reviewers should not give too much weightage to the past speaking experience
    of the speaker as PyCon India would like to encourage first time speakers.
    However, make sure the speaker is well qualified to give a talk on that topic.

